### PR TITLE
Fix: Clarify the behavior when _assessmentId is left blank (fixes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # adapt-assessmentResultsGraphic
 
 **Assessment Results Graphic** is a *presentation component* similar in behaviour to the Graphic component. However, a different graphic can be displayed based on the following state of the associated assessment:
+
 * incomplete
 * failed
 * passed
 
 The `_assessmentIncomplete` image is only needed if the Assessment Results Graphic can been seen by the learner prior to assessment completion (i.e. it hasn't been hidden either by the Trickle extension or by using `_isVisibleBeforeCompletion: false`). Otherwise, it can safely be left out.
 
-It is expected that most of the time this component will have `_isOptional: true`. If it is _not_ optional, it does support the same `_setCompletionOn` settings as the Assessment Results component.
+It is expected that most of the time this component will have `_isOptional: true`. If it is *not* optional, it does support the same `_setCompletionOn` settings as the Assessment Results component.
 
 ## Settings Overview
 
@@ -15,33 +16,42 @@ The attributes listed below are used in *components.json* to configure **Assessm
 
 ## Attributes
 
-[**core model attributes**](https://github.com/adaptlearning/adapt_framework/wiki/Core-model-attributes): These are inherited by every Adapt component. [Read more](https://github.com/adaptlearning/adapt_framework/wiki/Core-model-attributes).
+The [**core model attributes**](https://github.com/adaptlearning/adapt_framework/wiki/Core-model-attributes) are inherited by every Adapt component. [Read more](https://github.com/adaptlearning/adapt_framework/wiki/Core-model-attributes)
 
-### \_component (string):
+### \_component (string)
+
 This must be set to: `"assessmentResultsGraphic"`.
 
-### \_classes (string):
+### \_classes (string)
+
 CSS class name(s) to be applied to this component's containing `div`. The class must be predefined in one of the Less files. Separate multiple classes with a space.
 
-### \_layout (string):
+### \_layout (string)
+
 This defines the horizontal position of the component in the block. Acceptable values are `full`, `left` or `right`.
 
-### \_assessmentId (string):
-This is the unique name of the assessment for which the graphic should be displayed.
+### \_assessmentId (string)
 
-### \_graphics (object):
+This value must match the [`_id` of the assessment](https://github.com/adaptlearning/adapt-contrib-assessment#attributes) for which the graphic should be displayed. If you only have *one* assessment, you can leave this blank (the article's `_assessment._id` must also be blank).
+
+### \_graphics (object)
+
 The object that defines the images to use for each assessment state. It contains the following settings that apply to the `_assessmentIncomplete`, `_assessmentPassed`, and `_assessmentFailed` objects.
 
-#### \_src (string):
-File name (including path) of the image. Path should be relative to the `src` folder (e.g. `"course/en/images/origami-menu-two.jpg"`).
+#### \_src (string)
 
-#### alt (string):
+File name (including path) of the image. Path should be relative to the `src` folder (e.g. `"course/en/images/assessment-pass.jpg"`).
+
+#### alt (string)
+
 The alternative text for this image. Assign [alt text](https://github.com/adaptlearning/adapt_framework/wiki/Providing-good-alt-text) to images that convey course content only.
 
 ## Accessibility
+
 The graphic displayed uses an [aria-label](https://github.com/adaptlearning/adapt_framework/wiki/Aria-Labels) attribute. This uses the content from each graphic's `alt` property. If `alt` is not set, the graphic will be hidden.
 
 ## Notes
+
 You *must* specify both the failed and passed images. If you don't want to have a different graphic for each of those assessment states, you should probably just be using the standard [Graphic component](https://github.com/adaptlearning/adapt-contrib-graphic).
 
 ## Limitations
@@ -49,8 +59,8 @@ You *must* specify both the failed and passed images. If you don't want to have 
 No known limitations.
 
 ----------------------------
-**Framework versions:** 5+<br>
-**Author / maintainer:**  Kineo<br>
+
+**Author / maintainer:**  CGKineo<br>
 **Accessibility support:** Yes<br>
 **RTL support:** Yes<br>
 **Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, Safari for macOS/iOS/iPadOS, Opera<br>

--- a/properties.schema
+++ b/properties.schema
@@ -27,7 +27,7 @@
       "required": true,
       "title": "Assessment Name",
       "default": "",
-      "help": "The unique name of the assessment for which the graphic should be displayed.",
+      "help": "The unique name of the assessment for which the graphic should be displayed. If you only have one assessment, you can leave this blank (the article's assessment ID must also be blank)",
       "inputType": "Text",
       "validators": []
     },

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -23,7 +23,7 @@
           "type": "string",
           "title": "Assessment Name",
           "default": "",
-          "description": "The unique name of the assessment for which the graphic should be displayed."
+          "description": "The unique name of the assessment for which the graphic should be displayed. If you only have one assessment, you can leave this blank (the article's assessment ID must also be blank)"
         },
         "_isVisibleBeforeCompletion": {
           "type": "boolean",


### PR DESCRIPTION
Fix #7 

### Fix
* Clarifies the behavior when `_assessmentId` is left blank. The article's assessment ID must _also_ be blank, and this was not made clear in the documentation or schemas. Aligns with Assessment Results [PR 85](https://github.com/adaptlearning/adapt-contrib-assessmentResults/pull/85).
* Readme: Markdown linting fixes, remove required FW version, update "CGKineo" name